### PR TITLE
specs: Add a `place` method

### DIFF
--- a/php-apache.js
+++ b/php-apache.js
@@ -11,4 +11,8 @@ App.prototype.deploy = function(deployment) {
     deployment.deploy(this.service);
 };
 
+App.prototype.place = function(rule) {
+    this.service.place(rule);
+};
+
 module.exports = App;


### PR DESCRIPTION
The `place` method applies to the service containing the PHP/Apache container.
This function is needed for the website deployment.