### PR TITLE
spec: Migrate to Node.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
-var App = require("github.com/quilt/php-apache");
+const {createDeployment, Machine} = require("@quilt/quilt");
+var App = require("./php-apache.js");
 
 var deployment = createDeployment();
 

--- a/package.json
+++ b/package.json
@@ -1,3 +1,9 @@
 {
-    "main": "./php-apache.js"
+  "name": "@quilt/php-apache",
+  "version": "0.0.1",
+  "main": "./php-apache.js",
+  "license": "MIT",
+  "dependencies": {
+    "@quilt/quilt": "quilt/quilt"
+  }
 }

--- a/php-apache.js
+++ b/php-apache.js
@@ -1,3 +1,4 @@
+const {Container, Service, publicInternet} = require("@quilt/quilt");
 var defaultImage = "quilt/php-apache";
 
 function App(image) {


### PR DESCRIPTION
`quilt run` now runs within the Node.js runtime. This is a breaking
change, requiring a number of changes to our specs.